### PR TITLE
Avoid using Map() on parse

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
 class Toggle {
 
 	constructor(toggleEl, config) {
+		if (!Toggle._toggles) {
+			Toggle._toggles = new Map();
+		}
 		if (!toggleEl) {
 			return;
 		} else if (!(toggleEl instanceof HTMLElement)) {
@@ -93,7 +96,6 @@ class Toggle {
 	}
 
 	static init(el, config) {
-		Toggle._toggles = new Map();
 		if (!el) {
 			el = document.body;
 		} else if (!(el instanceof HTMLElement)) {

--- a/main.js
+++ b/main.js
@@ -93,6 +93,7 @@ class Toggle {
 	}
 
 	static init(el, config) {
+		Toggle._toggles = new Map();
 		if (!el) {
 			el = document.body;
 		} else if (!(el instanceof HTMLElement)) {
@@ -108,8 +109,6 @@ class Toggle {
 		return toggles;
 	}
 };
-
-Toggle._toggles = new Map();
 
 const constructAll = () => {
 	Toggle.init();

--- a/main.js
+++ b/main.js
@@ -10,9 +10,9 @@ class Toggle {
 			toggleEl = document.querySelector(toggleEl);
 		}
 
-			if (toggleEl.hasAttribute('data-o-toggle--js')) {
-				return;
-			}
+		if (toggleEl.hasAttribute('data-o-toggle--js')) {
+			return;
+		}
 
 		if (!config) {
 			config = {};


### PR DESCRIPTION
@jakechampion

This makes me think that a standard test case to add to origami is that modules should not error when compiled without babel polyfills and loaded in old browsers