### PR TITLE
Fix bug and add test

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ class Toggle {
 		// Generates a new array removing the current toggle from the list
 		Toggle._toggles.set(this.targetEl,
 							targetArray.slice(0, togglePosition)
-										.join(targetArray.slice(togglePosition + 1)));
+										.concat(targetArray.slice(togglePosition + 1)));
 
 		this.targetEl = undefined;
 		this.toggleEl = undefined;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -158,4 +158,40 @@ describe('Toggle', () => {
 
 		document.body.removeChild(toggleEl2);
 	});
+
+	describe("destroy", () => {
+		it("should remove itself but not remove anything else from the global target->toggles Map", () => {
+			const toggleEl2 = document.createElement('button');
+			toggleEl2.setAttribute('data-o-toggle-target', 'div');
+			toggleEl2.setAttribute('data-o-toggle-callback', 'console.log("test");');
+			document.body.appendChild(toggleEl2);
+
+			const testToggle2 = new Toggle(toggleEl2);
+
+			/* create another toggle that targets the same element */
+			const toggleEl3 = document.createElement('button');
+			toggleEl3.setAttribute('data-o-toggle-target', 'div');
+			toggleEl3.setAttribute('data-o-toggle-callback', 'console.log("test");');
+			document.body.appendChild(toggleEl3);
+
+			const testToggle3 = new Toggle(toggleEl3);
+
+			const testToggle2TargetEl = testToggle2.targetEl;
+
+			// These two toggles both affect the same target.
+			expect(testToggle2.targetEl).to.equal(testToggle3.targetEl);
+			expect(Toggle._toggles.has(testToggle2TargetEl)).to.be(true);
+			expect(Toggle._toggles.get(testToggle2TargetEl)).to.contain(testToggle2);
+			expect(Toggle._toggles.get(testToggle2TargetEl)).to.contain(testToggle3);
+
+
+			testToggle2.destroy();
+
+			expect(Toggle._toggles.has(testToggle2TargetEl)).to.be(true);
+			expect(Toggle._toggles.get(testToggle2TargetEl)).to.not.contain(testToggle2);
+			expect(Toggle._toggles.get(testToggle2TargetEl)).to.contain(testToggle3);
+
+
+		});
+	});
 });


### PR DESCRIPTION
In the destroy method, .join has been used instead of .concat to merge
two arrays. This is not what .join does so when the destroy method is
called instead of removing a toggle from the array of toggles, it
reassigns the target->toggle array map to target->empty string.

This commit fixes the problem and adds a test that checks that destroy
only removes one toggle from the target->toggle map and leaves the other.

This test file could do with refactoring but that is a job for another
day so for now I've just added this test to the bottom of the file.