### PR TITLE
Add styles so o-toggle may be used without custom CSS.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,3 +2,4 @@
 
 ### Migrating from v1 to v2
 
+No changes are required. Optionally, you may be able to remove CSS from your project and use one of two CSS classes `o-toggle` now provides to help hide a target when the toggle is not active (`o-toggle-display` and `o-toggle-visibility`).

--- a/README.md
+++ b/README.md
@@ -4,23 +4,45 @@ This utility component adds toggle (show/hide) behaviour to a `<button>` or `<a>
 
 - [Markup](#markup)
 - [JavaScript](#javascript)
+- [Sass](#sass)
 - [Contact](#contact)
 - [Licence](#licence)
 
 ## Markup
 
-Add the toggle data attributes to your toggle such as a `<button>`, where the value of `data-o-toggle-target` is the CSS selector for the element you want to show/hide. E.g:
+Add the `data-o-component="o-toggle"` and `data-o-toggle-target` to your toggle element (e.g. `<button>`). Where the value of `data-o-toggle-target` is the CSS selector for the element you want to show/hide.
+
+When the toggle is clicked a class `o-toggle--active` is toggled on the target as well as its `aria-hidden` attribute. Use these in your project to style the target according to if the toggle is on or off. Alternatively, add the class `o-toggle-display` (to totally hide the target) or `o-toggle-visibility` (to layout but visually hide the target) when the toggle is not active.
 
 ```html
 <button data-o-component="o-toggle" data-o-toggle-target="#my-target">My button</button>
-<div id='my-target'>Some toggleable content</div>
+<div id='my-target' class="o-toggle o-toggle-display">Some toggleable content</div>
 ```
 
 The data attribute `data-o-toggle-callback` may also be set to the content of a function as _string_ that will be executed every time a toggle happens. E.g:
 
-<button data-o-component="o-toggle" data-o-toggle-target="#my-target" data-o-toggle-callback="console.log('toggled!');">
-</button>
-<div id='my-target'>Some toggleable content</div>
+```html
+<button data-o-component="o-toggle" data-o-toggle-target="#my-target">My button</button>
+<div id='my-target' class="o-toggle o-toggle-display" data-o-toggle-callback="console.log('toggled!');">Some toggleable content</div>
+```
+
+## Sass
+
+Projects may choose to style active targets themselves using the `o-toggle--active` class or `aria-hidden` attribute. However to use the `o-toggle` helper classes `o-toggle-display` and `o-toggle-visibility` classes (see [Markup](#markup) call the mixin `@include oToggle()`:
+
+```scss
+@include oToggle();
+```
+
+Alternatively the classes may be included granularly with an `$opts` map:
+
+```scss
+@include oToggle($opts: ('display': true));
+```
+or
+```scss
+@include oToggle($opts: ('visibility': true));
+```
 
 ## JavaScript
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,14 @@
 {
   "name": "o-toggle",
   "main": [
-    "main.js"
+    "main.js",
+    "main.scss"
+  ],
+  "ignore": [
+    ".gitignore",
+    "build",
+    "test",
+    "karma.conf.js",
+    "package.json"
   ]
 }

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,5 +1,2 @@
-<button class='demo-toggle' data-o-component="o-toggle"
-		data-o-toggle-target=".demo-target"
-		data-o-toggle-callback="document.querySelector('.demo-target').classList.toggle('hidden');">Toggle</button>
-
-<div class="demo-target hidden">Target of the toggle</div>
+<button data-o-component="o-toggle" data-o-toggle-target="#demo-target" class='o-buttons o-buttons--primary'>{{type}} toggle</button>
+<div id="demo-target" class="o-toggle o-toggle-{{type}}">Target of the toggle</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,21 +1,11 @@
+$o-toggle-is-silent: false;
+@import "./../../main";
+
 body {
-	background-color: #cccccc;
-}
-.hidden {
-	visibility: hidden;
+	margin: var(--o-spacing-s4, 1rem);
 }
 
-.demo-toggle {
-	margin: 1em;
-	font-size: 20px;
-}
-
-.demo-target {
-	font-family: arial;
-	font-size: 20px;
-	display: block;
-	background-color: grey;
-	width: 50%;
-	padding: 1em;
-	margin: 1em;
+#demo-target {
+	font-family: if(oBrandGetCurrentBrand() == 'whitelabel', Arial, MetricWeb);
+	margin: var(--o-spacing-s4, 1rem) 0;
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -5,7 +5,9 @@ body {
 	margin: var(--o-spacing-s4, 1rem);
 }
 
+// sass-lint:disable no-ids
 #demo-target {
 	font-family: if(oBrandGetCurrentBrand() == 'whitelabel', Arial, MetricWeb);
 	margin: var(--o-spacing-s4, 1rem) 0;
 }
+// sass-lint:enable no-ids

--- a/main.scss
+++ b/main.scss
@@ -1,0 +1,38 @@
+@import "src/scss/variables";
+
+/// Outputs toggle stlyes.
+/// @param {list} $opts [('display': true, 'visibility': true)] - A map of which default toggle classes to output, i.e. `o-toggle-display`, `o-toggle-visibility`.
+/// @example Output all default o-toggle features.
+///     @include oToggle();
+/// @example Output only the styles for a toggle which applies `display: none` when inactive.
+///     @include oToggle($opts: ('display': true));
+/// @example Output only the styles for a toggle which applies `visibility: hidden` when inactive.
+///     @include oToggle($opts: ('visibility': true));
+/// @example Output all o-toggle features.
+/// @access public
+@mixin oToggle($opts: (
+	'display': true,
+	'visibility': true
+)) {
+    $display: map-get($opts, 'display');
+    $visibility: map-get($opts, 'visibility');
+
+	@if $display {
+        .o-toggle-display:not(.o-toggle--active) {
+            display: none;
+        }
+    }
+
+	@if $visibility {
+        .o-toggle-visibility:not(.o-toggle--active) {
+            visibility: hidden;
+        }
+	}
+}
+
+@if ($o-toggle-is-silent == false) {
+	@include oToggle();
+
+	// Set toggle to silent again to avoid being output twice
+	$o-toggle-is-silent: true !global;
+}

--- a/main.scss
+++ b/main.scss
@@ -14,19 +14,19 @@
 	'display': true,
 	'visibility': true
 )) {
-    $display: map-get($opts, 'display');
-    $visibility: map-get($opts, 'visibility');
+	$display: map-get($opts, 'display');
+	$visibility: map-get($opts, 'visibility');
 
 	@if $display {
-        .o-toggle-display:not(.o-toggle--active) {
-            display: none;
-        }
-    }
+		.o-toggle-display:not(.o-toggle--active) {
+			display: none;
+		}
+	}
 
 	@if $visibility {
-        .o-toggle-visibility:not(.o-toggle--active) {
-            visibility: hidden;
-        }
+		.o-toggle-visibility:not(.o-toggle--active) {
+			visibility: hidden;
+		}
 	}
 }
 

--- a/origami.json
+++ b/origami.json
@@ -14,16 +14,33 @@
     "circle": "https://circleci.com/api/v1/project/Financial-Times/o-toggle"
   },
   "demosDefaults": {
-    "js": "demos/src/demo.js"
+    "js": "demos/src/demo.js",
+    "sass": "demos/src/demo.scss",
+    "dependencies": [
+      "o-spacing@^2.0.0",
+      "o-fonts@^3.0.0",
+      "o-normalise@^1.0.0",
+      "o-buttons@^5.16.2"
+    ]
   },
   "demos": [
     {
-      "title": "Toggles",
-      "name": "toggles",
+      "title": "Toggle display on/off.",
+      "name": "display-toggle",
       "template": "demos/src/demo.mustache",
-      "sass": "demos/src/demo.scss",
-      "hidden": false,
-      "description": "The toggle button updates aria attributes on the targets and adds a class."
+      "data": {
+        "type": "display"
+      },
+      "description": "This toggle target has a class \"o-toggle-display\" which hides it until clicking the toggle updates its aria attributes and adds the \"o-toggle--active\" class."
+    },
+    {
+      "title": "Toggle visibility.",
+      "name": "visibility-toggle",
+      "template": "demos/src/demo.mustache",
+      "data": {
+        "type": "visibility"
+      },
+      "description": "This toggle target has a class \"o-toggle-visibility\" which visually hides it, whilst still occupying space, until clicking the toggle updates its aria attributes and adds the \"o-toggle--active\" class."
     }
   ]
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,0 +1,2 @@
+/// @type Bool
+$o-toggle-is-silent: true !default;


### PR DESCRIPTION
- Adds `o-toggle-visibility`, to set `visibility: hidden`
on an active target.
- Adds `o-toggle-display`, to set `display: none` on an
active target.
- Keeps current behavior without these classes.

https://github.com/Financial-Times/o-toggle/issues/18


<img width="218" alt="Screenshot 2019-09-02 at 16 30 18" src="https://user-images.githubusercontent.com/10405691/64124455-f9bdc080-cd9e-11e9-9491-5f00ac0d6391.png">