### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import '../../main';
+import '../../main.js';
 
 document.addEventListener("DOMContentLoaded", function () {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Toggle from './src/js/toggle';
+import Toggle from './src/js/toggle.js';
 
 const constructAll = () => {
 	Toggle.init();

--- a/src/js/toggle.js
+++ b/src/js/toggle.js
@@ -1,4 +1,4 @@
-import Target from './target';
+import Target from './target.js';
 
 // Some assistive technologies, like screen readers, suggest to press 'space'
 // when interacting with a link with a role of 'button'.

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import oToggle from './../main';
+import oToggle from './../main.js';
 
 describe("oToggle", () => {
 	it('is defined', () => {

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import OToggle from './../main';
+import OToggle from './../main.js';
 
 describe("Target", () => {
 

--- a/test/toggle.test.js
+++ b/test/toggle.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import OToggle from './../main';
+import OToggle from './../main.js';
 
 export function dispatch (target, type, eventProperties) {
 	const event = new Event(type, { bubbles: true });


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing